### PR TITLE
Acceso a solución solo si la lección fue completada

### DIFF
--- a/services/learning-service/src/controllers/solutions.controller.js
+++ b/services/learning-service/src/controllers/solutions.controller.js
@@ -1,0 +1,17 @@
+const { asyncHandler, parsePositiveInt } = require('@codequest/shared')
+const { learningService } = require('../services/container')
+
+const getLessonSolution = asyncHandler(async (req, res) => {
+  const lessonId = parsePositiveInt(req.params.lessonId, 'lessonId')
+
+  const solution = await learningService.getLessonSolution({
+    lessonId,
+    userId: req.user.id,
+  })
+
+  return res.status(200).json(solution)
+})
+
+module.exports = {
+  getLessonSolution,
+}

--- a/services/learning-service/src/repositories/solutions.repository.js
+++ b/services/learning-service/src/repositories/solutions.repository.js
@@ -5,7 +5,7 @@ class SolutionsRepository {
 
   /**
    * Devuelve la solución registrada en BD para una lección específica.
-   * Retorna null si no existe registro (permite fallback al objeto hardcodeado).
+   * Retorna null si no existe registro.
    */
   async findByLesson(lessonId) {
     const [rows] = await this.pool.query(
@@ -17,6 +17,39 @@ class SolutionsRepository {
     )
 
     return rows[0] || null
+  }
+
+  /**
+   * Devuelve la solución oficial de una lección para mostrarla al usuario.
+   * Incluye el código resuelto (base_code con _____ reemplazado por solution_code).
+   */
+  async getSolutionForUser(lessonId) {
+    const [rows] = await this.pool.query(
+      `SELECT ls.lesson_id,
+              ls.solution_code,
+              ls.explanation,
+              ls.base_code,
+              l.title AS lesson_title
+       FROM lesson_solutions ls
+       JOIN lessons l ON l.id = ls.lesson_id
+       WHERE ls.lesson_id = ?
+         AND l.is_published = 1
+       LIMIT 1`,
+      [lessonId]
+    )
+
+    if (!rows[0]) return null
+
+    const row = rows[0]
+
+    return {
+      lesson_id:    Number(row.lesson_id),
+      lesson_title: row.lesson_title,
+      solution_code: row.solution_code,
+      explanation:  row.explanation,
+      base_code:    row.base_code,
+      solved_code:  (row.base_code || '').replace('_____', row.solution_code),
+    }
   }
 }
 

--- a/services/learning-service/src/routes/learning.routes.js
+++ b/services/learning-service/src/routes/learning.routes.js
@@ -15,6 +15,7 @@ const {
 	submitSolution,
 } = require('../controllers/lessons.controller')
 const { getOverview, completeLesson } = require('../controllers/progress.controller')
+const { getLessonSolution } = require('../controllers/solutions.controller')
 const { listPathFavorites, togglePathFavorite, listLessonFavorites, toggleLessonFavorite } = require('../controllers/favorites.controller')
 
 const router = express.Router()
@@ -34,6 +35,7 @@ router.get('/paths/:pathId', featureFlagGuard('paths'), getPathById)
 
 router.get('/paths/:pathId/lessons', featureFlagGuard('lessons'), requireGatewayUser, listLessonsByPath)
 router.get('/lessons/completed', featureFlagGuard('lessons'), requireGatewayUser, listCompletedLessons)
+router.get('/lessons/:lessonId/solution', featureFlagGuard('lessons'), requireGatewayUser, getLessonSolution)
 router.get('/lessons/:lessonId', featureFlagGuard('lessons'), requireGatewayUser, getLessonById)
 router.get('/lessons/:lessonId/session', featureFlagGuard('lessons'), requireGatewayUser, getLessonSession)
 router.post(

--- a/services/learning-service/src/services/learning.service.js
+++ b/services/learning-service/src/services/learning.service.js
@@ -941,10 +941,20 @@ class LearningService {
 
   async getLessonSolution({ lessonId, userId }) {
     await this.schemaGuardService.assertGroup('lessons')
+    await this.schemaGuardService.assertGroup('progress')
 
     const lesson = await this.lessonsRepository.findById({ lessonId, userId })
     if (!lesson) {
       throw AppError.notFound('Lección no encontrada.')
+    }
+
+    // RN05: solo se puede ver la solución si el usuario completó la lección
+    const progress = await this.progressRepository.getProgressForLesson({ userId, lessonId })
+    if (!progress || progress.status !== 'completed') {
+      throw AppError.forbidden(
+        'Debes completar la lección antes de poder ver la solución.',
+        'LESSON_NOT_COMPLETED'
+      )
     }
 
     const solution = await this.solutionsRepository.getSolutionForUser(lessonId)

--- a/services/learning-service/src/services/learning.service.js
+++ b/services/learning-service/src/services/learning.service.js
@@ -939,6 +939,22 @@ class LearningService {
     }
   }
 
+  async getLessonSolution({ lessonId, userId }) {
+    await this.schemaGuardService.assertGroup('lessons')
+
+    const lesson = await this.lessonsRepository.findById({ lessonId, userId })
+    if (!lesson) {
+      throw AppError.notFound('Lección no encontrada.')
+    }
+
+    const solution = await this.solutionsRepository.getSolutionForUser(lessonId)
+    if (!solution) {
+      throw AppError.notFound('Esta lección no tiene una solución registrada.')
+    }
+
+    return solution
+  }
+
   async listLessonFavorites(userId) {
     await this.schemaGuardService.assertGroup('favorites')
     await this.schemaGuardService.assertGroup('base')


### PR DESCRIPTION
## Descripción
Se implementa la validación sobre el endpoint GET /api/learning/lessons/:id/solution. Antes de retornar la solución, el servicio verifica en user_progress que el usuario tenga la lección en estado completed. Si no la ha completado, el endpoint responde 403 con un mensaje claro.

## Fixes #42 

## Necesario
````
docker compose up -d --build
````
## Endpoint
```` 
GET /api/learning/lessons/:lessonId/solution
````
## Casos

````
Lección no completada   → 403 "Debes completar la lección antes de poder ver la solución."
Lección completada      → 200 { lesson_id, lesson_title, solution_code, explanation, solved_code }
Lección no existe       → 404 "Lección no encontrada."
Sin token               → 401
````

## Screenshots or videos
<img width="1563" height="392" alt="image" src="https://github.com/user-attachments/assets/33657ad3-fc9a-44ea-9b5d-80230c76502f" />

#### ⠀⠀⠀⠀⠀⠀⠀⠀⠀

<img width="1567" height="264" alt="image" src="https://github.com/user-attachments/assets/0084b2c6-dc3a-4a6c-997a-7d22be34567d" />
