### PR TITLE
seguridad: corregir vulnerabilidades en ciclo de vida de tokens y sesiones

### DIFF
--- a/database/10_migration_security_fixes.sql
+++ b/database/10_migration_security_fixes.sql
@@ -1,0 +1,34 @@
+-- ============================================================
+-- MIGRATION 10: Security fixes
+-- - Add tokens_valid_after to users (invalidate sessions on password reset)
+-- - Fix cleanup event to include auth_tokens
+-- ============================================================
+
+USE `codequest`;
+
+-- Add tokens_valid_after column for session invalidation after password reset
+ALTER TABLE `users`
+  ADD COLUMN IF NOT EXISTS `tokens_valid_after` DATETIME NULL DEFAULT NULL
+  COMMENT 'All JWTs issued before this timestamp are considered invalid';
+
+-- Drop and recreate the cleanup event to include auth_tokens
+DROP EVENT IF EXISTS `cleanup_expired_tokens`;
+
+DELIMITER //
+
+CREATE EVENT `cleanup_expired_tokens`
+ON SCHEDULE EVERY 1 HOUR
+DO
+BEGIN
+    -- Clean up expired/used auth tokens (password reset, email verification)
+    DELETE FROM auth_tokens
+    WHERE expires_at < NOW() OR used_at IS NOT NULL;
+
+    -- Clean up expired blacklisted tokens
+    DELETE FROM token_blacklist WHERE expires_at < NOW();
+END //
+
+DELIMITER ;
+
+-- Enable event scheduler if not already on (idempotent hint for DBAs)
+-- SET GLOBAL event_scheduler = ON;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,12 @@ services:
       LEARNING_SERVICE_URL: http://learning-service:4002
       JWT_ACCESS_SECRET: change_me_access_secret
       JWT_REFRESH_SECRET: change_me_refresh_secret
+      DB_HOST: mariadb
+      DB_PORT: 3306
+      DB_USER: codequest
+      DB_PASSWORD: codequest
+      DB_NAME: codequest
+      AUTH_VALIDATION_FAIL_OPEN: 'false'
     depends_on:
       auth-service:
         condition: service_healthy

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -5,6 +5,7 @@ const errorHandler = require('./http/errorHandler')
 const notFoundHandler = require('./http/notFoundHandler')
 const { requireFields, parsePositiveInt, parseString } = require('./validation/request')
 const { createJwtToolkit } = require('./security/jwt')
+const { hashToken } = require('./security/tokenHash')
 const {
   ROLE_USER,
   ROLE_INSTRUCTOR,
@@ -29,6 +30,7 @@ module.exports = {
   parsePositiveInt,
   parseString,
   createJwtToolkit,
+  hashToken,
   ROLE_USER,
   ROLE_INSTRUCTOR,
   ROLE_ADMIN,

--- a/packages/shared/src/middleware/authGuard.js
+++ b/packages/shared/src/middleware/authGuard.js
@@ -35,7 +35,7 @@ function createAuthGuard({ verifyAccessToken, isTokenRevoked } = {}) {
     }
 
     if (typeof isTokenRevoked === 'function') {
-      const revoked = await isTokenRevoked(token)
+      const revoked = await isTokenRevoked(token, decoded, req)
       if (revoked) {
         return next(AppError.unauthorized('Token revocado.', 'TOKEN_REVOKED'))
       }

--- a/packages/shared/src/security/jwt.js
+++ b/packages/shared/src/security/jwt.js
@@ -1,4 +1,5 @@
 const jwt = require('jsonwebtoken')
+const { randomUUID } = require('crypto')
 
 function createJwtToolkit({
   accessSecret,
@@ -11,11 +12,11 @@ function createJwtToolkit({
   }
 
   function signAccessToken(payload) {
-    return jwt.sign(payload, accessSecret, { expiresIn: accessExpiresIn })
+    return jwt.sign({ ...payload, jti: randomUUID() }, accessSecret, { expiresIn: accessExpiresIn })
   }
 
   function signRefreshToken(payload) {
-    return jwt.sign(payload, refreshSecret, { expiresIn: refreshExpiresIn })
+    return jwt.sign({ ...payload, jti: randomUUID() }, refreshSecret, { expiresIn: refreshExpiresIn })
   }
 
   function verifyAccessToken(token) {

--- a/packages/shared/src/security/tokenHash.js
+++ b/packages/shared/src/security/tokenHash.js
@@ -1,0 +1,9 @@
+const crypto = require('crypto')
+
+function hashToken(token) {
+  return crypto.createHash('sha256').update(String(token)).digest('hex')
+}
+
+module.exports = {
+  hashToken,
+}

--- a/services/api-gateway/src/config/env.js
+++ b/services/api-gateway/src/config/env.js
@@ -6,6 +6,23 @@ function toInteger(value, fallback) {
   return Number.isInteger(parsed) ? parsed : fallback
 }
 
+function toBoolean(value, fallback) {
+  if (value === undefined) {
+    return fallback
+  }
+
+  const normalized = String(value).trim().toLowerCase()
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true
+  }
+
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false
+  }
+
+  return fallback
+}
+
 const env = {
   nodeEnv: process.env.NODE_ENV || 'development',
   serviceName: 'api-gateway',
@@ -17,6 +34,14 @@ const env = {
     accessSecret: process.env.JWT_ACCESS_SECRET || 'dev_access_secret_change_me',
     refreshSecret: process.env.JWT_REFRESH_SECRET || 'dev_refresh_secret_change_me',
   },
+  db: {
+    host: process.env.DB_HOST || 'localhost',
+    port: toInteger(process.env.DB_PORT, 3306),
+    user: process.env.DB_USER || 'codequest',
+    password: process.env.DB_PASSWORD || '',
+    database: process.env.DB_NAME || 'codequest',
+  },
+  authValidationFailOpen: toBoolean(process.env.AUTH_VALIDATION_FAIL_OPEN, false),
 }
 
 module.exports = { env }

--- a/services/api-gateway/src/middleware/gateway-auth.js
+++ b/services/api-gateway/src/middleware/gateway-auth.js
@@ -9,8 +9,8 @@ function isPublicLearningRoute(req) {
   return /^\/api\/learning\/paths(\/\d+)?$/.test(path)
 }
 
-function createGatewayAuth({ verifyAccessToken }) {
-  return (req, _res, next) => {
+function createGatewayAuth({ verifyAccessToken, isTokenRevoked, authValidationFailOpen = false }) {
+  return async (req, _res, next) => {
     if (isPublicLearningRoute(req)) {
       return next()
     }
@@ -20,15 +20,9 @@ function createGatewayAuth({ verifyAccessToken }) {
       return next(AppError.unauthorized('Token de autenticacion requerido en gateway.'))
     }
 
+    let decoded
     try {
-      const decoded = verifyAccessToken(token)
-      req.gatewayUser = {
-        id: decoded.id,
-        email: decoded.email,
-        role: normalizeRole(decoded.role),
-      }
-      req.gatewayToken = token
-      return next()
+      decoded = verifyAccessToken(token)
     } catch (error) {
       if (error.name === 'TokenExpiredError') {
         return next(AppError.unauthorized('Token expirado.', 'TOKEN_EXPIRED'))
@@ -36,6 +30,29 @@ function createGatewayAuth({ verifyAccessToken }) {
 
       return next(AppError.unauthorized('Token invalido.', 'TOKEN_INVALID'))
     }
+
+    try {
+      const revoked = await isTokenRevoked(token, decoded, req)
+      if (revoked) {
+        return next(AppError.unauthorized('Token revocado.', 'TOKEN_REVOKED'))
+      }
+    } catch (error) {
+      if (authValidationFailOpen) {
+        console.error('[gateway-auth] No se pudo validar la sesion, continuando en fail-open:', error?.message)
+      } else {
+        return next(AppError.serviceUnavailable('No se pudo validar la sesion.', 'AUTH_VALIDATION_UNAVAILABLE', {
+          reason: error?.message,
+        }))
+      }
+    }
+
+    req.gatewayUser = {
+      id: decoded.id,
+      email: decoded.email,
+      role: normalizeRole(decoded.role),
+    }
+    req.gatewayToken = token
+    return next()
   }
 }
 

--- a/services/api-gateway/src/server.js
+++ b/services/api-gateway/src/server.js
@@ -4,6 +4,8 @@ const rateLimit = require('express-rate-limit')
 const { createProxyMiddleware } = require('http-proxy-middleware')
 const {
   createJwtToolkit,
+  createDbPool,
+  hashToken,
   asyncHandler,
   errorHandler,
   notFoundHandler,
@@ -15,6 +17,86 @@ const jwtToolkit = createJwtToolkit({
   accessSecret: env.jwt.accessSecret,
   refreshSecret: env.jwt.refreshSecret,
 })
+
+const dbPool = createDbPool({
+  host: env.db.host,
+  port: env.db.port,
+  user: env.db.user,
+  password: env.db.password,
+  database: env.db.database,
+})
+
+const TOKENS_VALID_AFTER_SCHEMA_CACHE_MS = 60 * 1000
+let usersTokensValidAfterColumn = null
+let usersTokensValidAfterColumnCheckedAt = 0
+let usersTokensValidAfterColumnPromise = null
+
+async function resolveUsersTokensValidAfterColumn() {
+  const now = Date.now()
+  if (
+    usersTokensValidAfterColumn !== null
+    && now - usersTokensValidAfterColumnCheckedAt < TOKENS_VALID_AFTER_SCHEMA_CACHE_MS
+  ) {
+    return usersTokensValidAfterColumn
+  }
+
+  if (usersTokensValidAfterColumnPromise) {
+    return usersTokensValidAfterColumnPromise
+  }
+
+  usersTokensValidAfterColumnPromise = dbPool.query(
+    `SELECT column_name
+     FROM information_schema.columns
+     WHERE table_schema = DATABASE()
+       AND table_name = 'users'
+       AND column_name = 'tokens_valid_after'`
+  ).then(([rows]) => {
+    usersTokensValidAfterColumn = rows.length > 0 ? 'tokens_valid_after' : ''
+    usersTokensValidAfterColumnCheckedAt = Date.now()
+    return usersTokensValidAfterColumn
+  }).catch((err) => {
+    usersTokensValidAfterColumnCheckedAt = 0
+    usersTokensValidAfterColumn = null
+    throw err
+  }).finally(() => {
+    usersTokensValidAfterColumnPromise = null
+  })
+
+  return usersTokensValidAfterColumnPromise
+}
+
+async function isTokenRevoked(token, decoded) {
+  const tokenHash = hashToken(token)
+  const [rows] = await dbPool.query(
+    `SELECT id FROM token_blacklist WHERE token_hash = ? AND expires_at > NOW() LIMIT 1`,
+    [tokenHash]
+  )
+
+  if (rows.length > 0) {
+    return true
+  }
+
+  const tokensValidAfterColumn = await resolveUsersTokensValidAfterColumn()
+  if (!tokensValidAfterColumn) {
+    return false
+  }
+
+  const [userRows] = await dbPool.query(
+    `SELECT ${tokensValidAfterColumn} AS tokens_valid_after
+     FROM users
+     WHERE id = ?
+     LIMIT 1`,
+    [decoded.id]
+  )
+
+  const user = userRows[0]
+  if (!user?.tokens_valid_after) {
+    return false
+  }
+
+  const validAfterTs = Math.floor(new Date(user.tokens_valid_after).getTime() / 1000)
+  return Number(decoded.iat) < validAfterTs
+}
 
 const app = express()
 
@@ -103,6 +185,8 @@ const proxyLearningService = createProxyMiddleware({
 
 const gatewayAuth = createGatewayAuth({
   verifyAccessToken: jwtToolkit.verifyAccessToken,
+  isTokenRevoked,
+  authValidationFailOpen: env.authValidationFailOpen,
 })
 
 app.use('/api/auth', authLimiter, proxyAuthService)
@@ -115,6 +199,35 @@ app.use('/api/admin', learningLimiter, gatewayAuth, proxyLearningService)
 app.use(notFoundHandler)
 app.use(errorHandler)
 
-app.listen(env.port, () => {
+const server = app.listen(env.port, () => {
   console.log(`[${env.serviceName}] running on http://localhost:${env.port}`)
 })
+
+let shuttingDown = false
+async function gracefulShutdown(signal) {
+  if (shuttingDown) {
+    return
+  }
+
+  shuttingDown = true
+  console.log(`[${env.serviceName}] ${signal} received, closing server...`)
+
+  server.close(async () => {
+    try {
+      await dbPool.end()
+      console.log(`[${env.serviceName}] DB connections closed.`)
+      process.exit(0)
+    } catch (error) {
+      console.error(`[${env.serviceName}] Error closing DB connections:`, error)
+      process.exit(1)
+    }
+  })
+
+  setTimeout(() => {
+    console.error(`[${env.serviceName}] forced shutdown due timeout.`)
+    process.exit(1)
+  }, 10000).unref()
+}
+
+process.on('SIGINT', () => gracefulShutdown('SIGINT'))
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))

--- a/services/auth-service/src/controllers/auth.controller.js
+++ b/services/auth-service/src/controllers/auth.controller.js
@@ -41,7 +41,7 @@ const refresh = asyncHandler(async (req, res) => {
 })
 
 const logout = asyncHandler(async (req, res) => {
-  await authService.logout({ req })
+  await authService.logout({ req, refreshToken: req.body?.refreshToken || null })
   return res.status(200).json({ message: 'Sesion cerrada correctamente.' })
 })
 

--- a/services/auth-service/src/repositories/auth-token.repository.js
+++ b/services/auth-service/src/repositories/auth-token.repository.js
@@ -34,6 +34,18 @@ class AuthTokenRepository {
       [tokenId]
     )
   }
+
+  async invalidatePreviousTokens({ userId, tokenType }) {
+    await this.pool.query(
+      `UPDATE auth_tokens
+       SET used_at = NOW()
+       WHERE user_id = ?
+         AND token_type = ?
+         AND used_at IS NULL
+         AND expires_at > NOW()`,
+      [userId, tokenType]
+    )
+  }
 }
 
 module.exports = AuthTokenRepository

--- a/services/auth-service/src/repositories/token-blacklist.repository.js
+++ b/services/auth-service/src/repositories/token-blacklist.repository.js
@@ -52,7 +52,10 @@ class TokenBlacklistRepository {
 
   async #resolveSchema() {
     if (!this.schemaPromise) {
-      this.schemaPromise = this.#detectSchema()
+      this.schemaPromise = this.#detectSchema().catch((err) => {
+        this.schemaPromise = null
+        throw err
+      })
     }
 
     return this.schemaPromise

--- a/services/auth-service/src/repositories/user.repository.js
+++ b/services/auth-service/src/repositories/user.repository.js
@@ -3,6 +3,7 @@ class UserRepository {
     this.pool = pool
     this.verifiedColumnPromise = null
     this.profileColumnsPromise = null
+    this.tokensValidAfterExistsPromise = null
   }
 
   async findByEmail(email) {
@@ -29,6 +30,7 @@ class UserRepository {
   async findById(id) {
     const verifiedColumn = await this.#resolveVerifiedColumn()
     const profileSelect = await this.#buildProfileSelectColumns()
+    const tvaColumn = await this.#resolveTokensValidAfterColumn()
     const [rows] = await this.pool.query(
       `SELECT id,
               name,
@@ -36,6 +38,7 @@ class UserRepository {
               role,
               is_active,
               ${profileSelect},
+              ${tvaColumn},
               ${verifiedColumn} AS is_email_verified
        FROM users
        WHERE id = ?
@@ -84,8 +87,9 @@ class UserRepository {
     )
   }
 
-  async updateProfileById(userId, { name, email, username, avatarUrl, countryCode, birthDate }) {
+  async updateProfileById(userId, { name, email, username, avatarUrl, countryCode, birthDate, emailChanged }) {
     const profileColumns = await this.#resolveProfileColumns()
+    const verifiedColumn = await this.#resolveVerifiedColumn()
     const updates = ['name = ?', 'email = ?']
     const params = [name, email]
 
@@ -107,6 +111,10 @@ class UserRepository {
     if (profileColumns.birth_date) {
       updates.push('birth_date = ?')
       params.push(birthDate)
+    }
+
+    if (emailChanged) {
+      updates.push(`${verifiedColumn} = 0`)
     }
 
     await this.pool.query(
@@ -219,7 +227,10 @@ class UserRepository {
 
   async #resolveVerifiedColumn() {
     if (!this.verifiedColumnPromise) {
-      this.verifiedColumnPromise = this.#detectVerifiedColumn()
+      this.verifiedColumnPromise = this.#detectVerifiedColumn().catch((err) => {
+        this.verifiedColumnPromise = null
+        throw err
+      })
     }
 
     return this.verifiedColumnPromise
@@ -263,7 +274,10 @@ class UserRepository {
 
   async #resolveProfileColumns() {
     if (!this.profileColumnsPromise) {
-      this.profileColumnsPromise = this.#detectProfileColumns()
+      this.profileColumnsPromise = this.#detectProfileColumns().catch((err) => {
+        this.profileColumnsPromise = null
+        throw err
+      })
     }
 
     return this.profileColumnsPromise
@@ -285,6 +299,42 @@ class UserRepository {
       avatar_url: columns.has('avatar_url'),
       country_code: columns.has('country_code'),
       birth_date: columns.has('birth_date'),
+    }
+  }
+
+  async #resolveTokensValidAfterColumn() {
+    if (!this.tokensValidAfterExistsPromise) {
+      this.tokensValidAfterExistsPromise = this.#detectTokensValidAfterColumn().catch((err) => {
+        this.tokensValidAfterExistsPromise = null
+        throw err
+      })
+    }
+
+    return this.tokensValidAfterExistsPromise
+  }
+
+  async #detectTokensValidAfterColumn() {
+    const [rows] = await this.pool.query(
+      `SELECT column_name
+       FROM information_schema.columns
+       WHERE table_schema = DATABASE()
+         AND table_name = 'users'
+         AND column_name = 'tokens_valid_after'`
+    )
+
+    return rows.length > 0 ? 'tokens_valid_after' : 'NULL AS tokens_valid_after'
+  }
+
+  async setTokensValidAfter(userId, date) {
+    try {
+      await this.pool.query(
+        `UPDATE users
+         SET tokens_valid_after = ?, updated_at = NOW()
+         WHERE id = ?`,
+        [date, userId]
+      )
+    } catch (_error) {
+      // Column may not exist yet if migration hasn't run — non-fatal
     }
   }
 }

--- a/services/auth-service/src/services/auth.service.js
+++ b/services/auth-service/src/services/auth.service.js
@@ -126,6 +126,11 @@ class AuthService {
       throw AppError.unauthorized('Refresh token invalido o expirado.')
     }
 
+    const isRevoked = await this.tokenBlacklistRepository.isTokenRevoked(refreshToken)
+    if (isRevoked) {
+      throw AppError.unauthorized('Refresh token revocado.')
+    }
+
     const user = await this.userRepository.findById(decoded.id)
     if (!user) {
       throw AppError.unauthorized('Usuario no encontrado.')
@@ -135,6 +140,13 @@ class AuthService {
       throw AppError.forbidden('Tu cuenta se encuentra desactivada.', 'ACCOUNT_DISABLED')
     }
 
+    if (user.tokens_valid_after) {
+      const validAfterTs = Math.floor(new Date(user.tokens_valid_after).getTime() / 1000)
+      if (Number(decoded.iat) < validAfterTs) {
+        throw AppError.unauthorized('Sesion invalidada. Por favor inicia sesion nuevamente.')
+      }
+    }
+
     const role = normalizeRole(user.role)
 
     return {
@@ -142,7 +154,7 @@ class AuthService {
     }
   }
 
-  async logout({ req }) {
+  async logout({ req, refreshToken }) {
     await this.schemaGuardService.assertReady()
 
     const token = extractBearerToken(req)
@@ -155,6 +167,10 @@ class AuthService {
       decoded = this.jwtToolkit.verifyAccessToken(token)
     } catch (error) {
       if (error.name === 'TokenExpiredError') {
+        // Even if access token expired, still revoke refresh token if provided
+        if (refreshToken) {
+          await this.#revokeRefreshToken(refreshToken)
+        }
         return
       }
 
@@ -168,6 +184,29 @@ class AuthService {
       userId: decoded.id,
       expiresAt,
     })
+
+    if (refreshToken) {
+      await this.#revokeRefreshToken(refreshToken)
+    }
+  }
+
+  async #revokeRefreshToken(refreshToken) {
+    let decodedRefresh
+    try {
+      decodedRefresh = this.jwtToolkit.verifyRefreshToken(refreshToken)
+    } catch (_error) {
+      return // Already expired or invalid — nothing to revoke
+    }
+
+    const expiresAt = decodedRefresh.exp
+      ? new Date(decodedRefresh.exp * 1000)
+      : new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+
+    await this.tokenBlacklistRepository.revokeToken({
+      token: refreshToken,
+      userId: decodedRefresh.id,
+      expiresAt,
+    })
   }
 
   async forgotPassword({ email }) {
@@ -177,6 +216,11 @@ class AuthService {
     if (!user) {
       return
     }
+
+    await this.authTokenRepository.invalidatePreviousTokens({
+      userId: user.id,
+      tokenType: 'reset_password',
+    })
 
     const rawToken = newRawToken()
     const tokenHash = hashToken(rawToken)
@@ -211,6 +255,7 @@ class AuthService {
 
     await this.userRepository.updatePasswordById(token.user_id, passwordHash)
     await this.authTokenRepository.markTokenUsed(token.id)
+    await this.userRepository.setTokensValidAfter(token.user_id, new Date())
   }
 
   async verifyEmail({ rawToken }) {
@@ -254,6 +299,8 @@ class AuthService {
       throw AppError.conflict('El email ya esta registrado.', 'EMAIL_ALREADY_REGISTERED')
     }
 
+    const emailChanged = email && email.toLowerCase() !== currentUser.email.toLowerCase()
+
     const updatedUser = await this.userRepository.updateProfileById(userId, {
       name: nombre,
       email,
@@ -261,6 +308,7 @@ class AuthService {
       avatarUrl: avatar,
       countryCode,
       birthDate,
+      emailChanged,
     })
 
     return mapUserPayload(updatedUser)

--- a/services/auth-service/src/services/container.js
+++ b/services/auth-service/src/services/container.js
@@ -35,9 +35,21 @@ const authService = new AuthService({
 
 const authGuard = createAuthGuard({
   verifyAccessToken: jwtToolkit.verifyAccessToken,
-  isTokenRevoked: async (token) => {
+  isTokenRevoked: async (token, decoded) => {
     await schemaGuardService.assertReady()
-    return tokenBlacklistRepository.isTokenRevoked(token)
+
+    const revoked = await tokenBlacklistRepository.isTokenRevoked(token)
+    if (revoked) {
+      return true
+    }
+
+    const user = await userRepository.findById(decoded.id)
+    if (!user || !user.tokens_valid_after) {
+      return false
+    }
+
+    const validAfterTs = Math.floor(new Date(user.tokens_valid_after).getTime() / 1000)
+    return Number(decoded.iat) < validAfterTs
   },
 })
 

--- a/services/auth-service/src/utils/tokenHash.js
+++ b/services/auth-service/src/utils/tokenHash.js
@@ -1,8 +1,5 @@
 const crypto = require('crypto')
-
-function hashToken(token) {
-  return crypto.createHash('sha256').update(String(token)).digest('hex')
-}
+const { hashToken } = require('@codequest/shared')
 
 function newRawToken() {
   return crypto.randomBytes(32).toString('hex')


### PR DESCRIPTION
- Se agrega jti (randomUUID) a todos los JWT firmados para evitar colisiones en blacklist
- logout() ahora revoca tanto el accessToken como el refreshToken
- refresh() verifica blacklist y tokens_valid_after antes de emitir nuevo accessToken
- resetPassword() invalida todas las sesiones activas mediante tokens_valid_after
- forgotPassword() invalida tokens de reset anteriores antes de crear uno nuevo
- updateProfile() resetea email_verified=0 cuando el email cambia
- El gateway ahora verifica blacklist y tokens_valid_after en cada request autenticado
- Comportamiento fail-open/fail-closed del gateway configurable via AUTH_VALIDATION_FAIL_OPEN
- Cache de tokens_valid_after en gateway con TTL y reintento seguro sin quedar envenenado
- Graceful shutdown restaurado en gateway (SIGINT/SIGTERM cierran server y dbPool)
- hashToken movido a @codequest/shared, eliminado duplicado del gateway
- schemaPromise, verifiedColumnPromise y profileColumnsPromise se resetean en error para reintentar
- Comparacion temporal cambiada de <= a < en todas las validaciones de tokens_valid_after
- Migracion 10: columna tokens_valid_after + evento cleanup_expired_tokens incluye auth_tokens"