### PR TITLE
Conecta el demo al locale y agrega traducciones base de contenido

### DIFF
--- a/database/21_migration_demo_content_i18n_core_languages.sql
+++ b/database/21_migration_demo_content_i18n_core_languages.sql
@@ -1,0 +1,139 @@
+-- Demo content i18n for core non-JavaScript languages.
+-- Adds English translations for the demo-facing lessons of Python, Java, C++, and C#,
+-- plus prompt/explanation translations for their lesson solutions.
+
+CREATE TEMPORARY TABLE demo_core_language_translation_seed (
+  lesson_slug VARCHAR(255) NOT NULL,
+  title_en VARCHAR(255) NOT NULL,
+  description_en TEXT NOT NULL,
+  content_en LONGTEXT NOT NULL,
+  explanation_en TEXT NOT NULL,
+  prompt_en TEXT NOT NULL
+);
+
+INSERT INTO demo_core_language_translation_seed VALUES
+('python-introduccion',
+'Introduction to Python',
+'Variables, data types, and running your first Python script.',
+'<h2>Introduction to Python</h2>
+<p>Python is one of the most popular languages in the world thanks to its readability and versatility. It is used in web development, data science, automation, and artificial intelligence.</p>
+<h3>Variables and basic types</h3>
+<p>In Python you do not need to declare the type of a variable. The interpreter infers it automatically:</p>
+<pre><code>name = "CodeQuest"   # str
+age  = 25            # int
+price = 9.99         # float
+active = True        # bool</code></pre>
+<h3>Console output</h3>
+<p>The <code>print()</code> function shows values in the console. You can pass any variable or expression to it:</p>
+<pre><code>print(name)              # CodeQuest
+print(age + 5)           # 30
+print(f"Hello, {name}!") # Hello, CodeQuest!</code></pre>
+<h3>Lists and transformations</h3>
+<p>Lists store ordered collections. List comprehensions let you transform them in a single line:</p>
+<pre><code>numbers = [1, 2, 3]
+doubles = [n * 2 for n in numbers]
+print(doubles)  # [2, 4, 6]</code></pre>
+<p>Practice identifying the variable name that stores the result of a transformation.</p>',
+'The variable <code>doubles</code> stores the transformed list that must be printed.',
+'Complete the missing identifier to print the transformed list in Python.'),
+
+('java-clases-objetos',
+'Java: classes and objects',
+'Object-oriented programming in Java: classes, attributes, and methods.',
+'<h2>Classes and objects in Java</h2>
+<p>Java is an object-oriented language by design. All code lives inside classes, and objects are instances of those classes.</p>
+<h3>Defining a class</h3>
+<p>A class groups attributes (data) and methods (behavior):</p>
+<pre><code>public class Person {
+    private String name;
+    private int age;
+
+    public Person(String name, int age) {
+        this.name = name;
+        this.age  = age;
+    }
+
+    public String getName() { return this.name; }
+}</code></pre>
+<h3>Creating an object</h3>
+<p>You use <code>new</code> to instantiate a class, and the constructor runs automatically:</p>
+<pre><code>Person p = new Person("Ana", 28);
+System.out.println(p.getName());  // Ana</code></pre>
+<h3>Printing variables</h3>
+<p>The <code>System.out.println()</code> method accepts any type of data. When you pass a String variable, it displays its content:</p>
+<pre><code>String message = "Hello CodeQuest";
+System.out.println(message);  // Hello CodeQuest</code></pre>
+<p>Correctly identifying the variable that stores the value to print is a core debugging skill in Java.</p>',
+'<code>message</code> is the variable that stores the String value that must be printed.',
+'Complete the missing identifier to print the message in Java.'),
+
+('cpp-sintaxis-esencial',
+'C++: essential syntax',
+'Variables, control flow, functions, and input/output in C++.',
+'<h2>Essential syntax in C++</h2>
+<p>C++ combines the power of C with higher-level abstractions. It is the language behind game engines, operating systems, and high-performance software.</p>
+<h3>Variables and types</h3>
+<p>In C++ you must declare the type of every variable. The basic types are <code>int</code>, <code>double</code>, <code>char</code>, and <code>bool</code>:</p>
+<pre><code>int total = 2 + 3;
+double price = 19.99;
+bool active = true;</code></pre>
+<h3>Output with cout</h3>
+<p>The <code><<</code> operator chains values into the standard output:</p>
+<pre><code>std::cout << total << std::endl;   // 5
+std::cout << "Price: " << price;   // Price: 19.99</code></pre>
+<h3>Control flow</h3>
+<p>The <code>if/else</code> structures and <code>for</code>/<code>while</code> loops work much like they do in many other languages:</p>
+<pre><code>for (int i = 0; i < 5; i++) {
+    std::cout << i << " ";
+}
+// 0 1 2 3 4</code></pre>
+<p>The key to debugging in C++ is naming your variables clearly and using them correctly with <code>cout</code>.</p>',
+'<code>total</code> stores the calculated value that must be sent to <code>cout</code>.',
+'Complete the missing identifier to show the result in C++.'),
+
+('csharp-dotnet-primeros-pasos',
+'C# and .NET: first steps',
+'Project structure, basic types, and console output in C#.',
+'<h2>First steps with C# and .NET</h2>
+<p>C# is the main language of Microsoft''s .NET ecosystem. It is used for web development (ASP.NET), desktop applications (WPF/MAUI), games (Unity), and cloud services.</p>
+<h3>Program structure</h3>
+<p>A minimal C# program has a namespace, a class, and the static <code>Main</code> method:</p>
+<pre><code>namespace MyApp {
+    class Program {
+        static void Main(string[] args) {
+            Console.WriteLine("Hello, .NET!");
+        }
+    }
+}</code></pre>
+<h3>Variables and types</h3>
+<p>C# is strongly typed but allows inference with <code>var</code>:</p>
+<pre><code>int total = 2 + 3;
+var message = "Result: " + total;
+Console.WriteLine(message);  // Result: 5</code></pre>
+<h3>Console output</h3>
+<p><code>Console.WriteLine()</code> prints the value of any variable and adds a line break:</p>
+<pre><code>int total = 2 + 3;
+Console.WriteLine(total);  // 5</code></pre>
+<p>Learn to identify the variable that stores the result of an operation: that is what you pass to <code>Console.WriteLine()</code>.</p>',
+'<code>total</code> is the variable that stores the result that must be printed.',
+'Complete the missing identifier to print the result in C#.');
+
+INSERT INTO lesson_translations (lesson_id, locale, title, description, content)
+SELECT l.id, 'en', seed.title_en, seed.description_en, seed.content_en
+FROM demo_core_language_translation_seed seed
+JOIN lessons l ON l.slug = seed.lesson_slug
+ON DUPLICATE KEY UPDATE
+  title = VALUES(title),
+  description = VALUES(description),
+  content = VALUES(content);
+
+INSERT INTO lesson_solution_translations (lesson_solution_id, locale, explanation, prompt)
+SELECT ls.id, 'en', seed.explanation_en, seed.prompt_en
+FROM demo_core_language_translation_seed seed
+JOIN lessons l ON l.slug = seed.lesson_slug
+JOIN lesson_solutions ls ON ls.lesson_id = l.id
+ON DUPLICATE KEY UPDATE
+  explanation = VALUES(explanation),
+  prompt = VALUES(prompt);
+
+DROP TEMPORARY TABLE demo_core_language_translation_seed;

--- a/database/22_migration_demo_path_i18n_core_languages.sql
+++ b/database/22_migration_demo_path_i18n_core_languages.sql
@@ -1,0 +1,40 @@
+-- Demo path i18n for core non-JavaScript languages.
+-- Adds English translations for the learning paths shown as modules/cards
+-- for Python, Java, C++, and C#.
+
+CREATE TEMPORARY TABLE demo_core_path_translation_seed (
+  path_slug VARCHAR(255) NOT NULL,
+  name_en VARCHAR(255) NOT NULL,
+  description_en TEXT NOT NULL
+);
+
+INSERT INTO demo_core_path_translation_seed VALUES
+('python-basics',
+'Python from Scratch',
+'Learn Python from the fundamentals up to intermediate concepts.'),
+
+('python-intermediate',
+'Intermediate Python',
+'Master data structures and algorithms in Python.'),
+
+('java-fundamentals',
+'Java Fundamentals',
+'Introduction to Java and object-oriented programming.'),
+
+('cpp-basics',
+'C++ for Beginners',
+'Learn C++ from scratch with practical exercises.'),
+
+('csharp-dotnet',
+'C# and .NET',
+'Application development with C# and .NET.');
+
+INSERT INTO learning_path_translations (learning_path_id, locale, name, description)
+SELECT lp.id, 'en', seed.name_en, seed.description_en
+FROM demo_core_path_translation_seed seed
+JOIN learning_paths lp ON lp.slug = seed.path_slug
+ON DUPLICATE KEY UPDATE
+  name = VALUES(name),
+  description = VALUES(description);
+
+DROP TEMPORARY TABLE demo_core_path_translation_seed;

--- a/services/learning-service/src/controllers/demo.controller.js
+++ b/services/learning-service/src/controllers/demo.controller.js
@@ -1,18 +1,43 @@
 const { AppError, asyncHandler, parsePositiveInt } = require('@codequest/shared')
 const { pool, learningService } = require('../services/container')
 
+function getRequestLocale(req) {
+  return String(req.headers['accept-language'] || '').toLowerCase().startsWith('en') ? 'en' : 'es'
+}
+
+function normalizeLanguageSlug(value) {
+  const normalized = String(value || '').trim().toLowerCase()
+  return normalized || null
+}
+
 /**
- * Devuelve el id de la primera leccion publicada marcada como is_free_demo.
- * Si no hay ninguna, lanza 404.
+ * Devuelve la primera leccion publicada disponible para el lenguaje solicitado.
+ * Si existe una marcada como is_free_demo, tiene prioridad. Si no, cae en la
+ * primera leccion publicada de ese lenguaje para que el selector del demo
+ * realmente cambie el contenido por tecnologia.
  */
-async function resolveDemoLessonId() {
+async function resolveDemoLessonId(languageSlug = null) {
+  const params = []
+  const languageFilter = languageSlug ? 'AND pl.slug = ?' : ''
+
+  if (languageSlug) {
+    params.push(languageSlug)
+  }
+
   const [rows] = await pool.query(
-    `SELECT id
-     FROM lessons
-     WHERE is_free_demo = 1
-       AND is_published = 1
-     ORDER BY id ASC
-     LIMIT 1`
+    `SELECT l.id
+     FROM lessons l
+     JOIN learning_paths lp ON lp.id = l.learning_path_id
+     JOIN programming_languages pl ON pl.id = lp.programming_language_id
+     WHERE l.is_published = 1
+       AND pl.is_active = 1
+       ${languageFilter}
+     ORDER BY CASE WHEN l.is_free_demo = 1 THEN 0 ELSE 1 END,
+              COALESCE(lp.order_position, 999),
+              COALESCE(l.order_position, 999),
+              l.id ASC
+     LIMIT 1`,
+    params
   )
 
   const row = rows[0]
@@ -24,15 +49,18 @@ async function resolveDemoLessonId() {
 }
 
 /**
- * Verifica que la leccion solicitada sea demo. Aplica RN07 (solo lecciones marcadas).
+ * Verifica que la leccion solicitada este publicada y pertenezca a un lenguaje
+ * activo, para que pueda usarse en el recorrido publico del demo.
  */
-async function assertLessonIsDemo(lessonId) {
+async function assertLessonAccessibleInDemo(lessonId) {
   const [rows] = await pool.query(
-    `SELECT id
-     FROM lessons
-     WHERE id = ?
-       AND is_free_demo = 1
-       AND is_published = 1
+    `SELECT l.id
+     FROM lessons l
+     JOIN learning_paths lp ON lp.id = l.learning_path_id
+     JOIN programming_languages pl ON pl.id = lp.programming_language_id
+     WHERE l.id = ?
+       AND l.is_published = 1
+       AND pl.is_active = 1
      LIMIT 1`,
     [lessonId]
   )
@@ -47,15 +75,19 @@ async function assertLessonIsDemo(lessonId) {
 
 /**
  * GET /api/learning/demo/lesson
- * Devuelve la leccion demo (la primera marcada como is_free_demo) con sus ejercicios.
+ * Devuelve la leccion demo con sus ejercicios.
  * Sin auth. No persiste nada en BD.
  */
-const getDemoLesson = asyncHandler(async (_req, res) => {
-  const lessonId = await resolveDemoLessonId()
+const getDemoLesson = asyncHandler(async (req, res) => {
+  const locale = getRequestLocale(req)
+  const languageSlug = normalizeLanguageSlug(req.query?.language)
+  const lessonId = await resolveDemoLessonId(languageSlug)
 
-  // Reutilizamos la logica existente. userId = 0 hace que el LEFT JOIN
-  // con user_progress no devuelva nada, por lo que status sera 'not_started'.
-  const payload = await learningService.getLessonSession({ lessonId, userId: 0 })
+  const payload = await learningService.getLessonSession({
+    lessonId,
+    userId: 0,
+    locale,
+  })
 
   return res.status(200).json({
     ...payload,
@@ -72,13 +104,14 @@ const submitDemoExercise = asyncHandler(async (req, res) => {
   const lessonId = parsePositiveInt(req.params.lessonId, 'lessonId')
   const exerciseId = String(req.params.exerciseId || '').trim()
 
-  await assertLessonIsDemo(lessonId)
+  await assertLessonAccessibleInDemo(lessonId)
 
   const result = await learningService.submitLessonExercise({
     userId: 0,
     lessonId,
     exerciseId,
     answer: req.body?.answer,
+    locale: getRequestLocale(req),
   })
 
   return res.status(200).json(result)
@@ -86,12 +119,31 @@ const submitDemoExercise = asyncHandler(async (req, res) => {
 
 /**
  * GET /api/learning/demo/preview
- * Devuelve metricas del catalogo para mostrar en la pantalla de completion
- * (lo que el usuario "desbloqueara" al registrarse).
+ * Devuelve metricas del catalogo y una previsualizacion localizada de las
+ * siguientes lecciones del lenguaje elegido.
  */
-const getDemoPreview = asyncHandler(async (_req, res) => {
+const getDemoPreview = asyncHandler(async (req, res) => {
+  const locale = getRequestLocale(req)
+  const languageSlug = normalizeLanguageSlug(req.query?.language)
+
+  const lessonCountParams = []
+  const lessonCountJoins = languageSlug
+    ? `JOIN learning_paths lp ON lp.id = l.learning_path_id
+       JOIN programming_languages pl ON pl.id = lp.programming_language_id`
+    : ''
+  const lessonCountFilter = languageSlug ? 'AND pl.slug = ?' : ''
+
+  if (languageSlug) {
+    lessonCountParams.push(languageSlug)
+  }
+
   const [[lessonsCountRow]] = await pool.query(
-    `SELECT COUNT(*) AS total FROM lessons WHERE is_published = 1`
+    `SELECT COUNT(*) AS total
+     FROM lessons l
+     ${lessonCountJoins}
+     WHERE l.is_published = 1
+       ${lessonCountFilter}`,
+    lessonCountParams
   )
 
   const [languagesRows] = await pool.query(
@@ -101,13 +153,26 @@ const getDemoPreview = asyncHandler(async (_req, res) => {
      ORDER BY id ASC`
   )
 
+  const nextLessonsParams = [locale]
+  const nextLessonsFilter = languageSlug ? 'AND pl.slug = ?' : ''
+  if (languageSlug) {
+    nextLessonsParams.push(languageSlug)
+  }
+
   const [nextLessonsRows] = await pool.query(
-    `SELECT title
-     FROM lessons
-     WHERE is_published = 1
-       AND is_free_demo = 0
-     ORDER BY id ASC
-     LIMIT 3`
+    `SELECT COALESCE(lt.title, l.title) AS title
+     FROM lessons l
+     JOIN learning_paths lp ON lp.id = l.learning_path_id
+     JOIN programming_languages pl ON pl.id = lp.programming_language_id
+     LEFT JOIN lesson_translations lt
+       ON lt.lesson_id = l.id
+      AND lt.locale = ?
+     WHERE l.is_published = 1
+       AND l.is_free_demo = 0
+       ${nextLessonsFilter}
+     ORDER BY l.id ASC
+     LIMIT 3`,
+    nextLessonsParams
   )
 
   return res.status(200).json({

--- a/services/learning-service/src/services/learning.service.js
+++ b/services/learning-service/src/services/learning.service.js
@@ -207,7 +207,86 @@ function inferBaseCodeByLanguage(languageId) {
   return 'resultado = 2 + 2\nprint(_____)'
 }
 
-function buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp }) {
+function getExerciseBankCopy(locale = 'es') {
+  if (locale === 'en') {
+    return {
+      fallbackGoalQuestion: 'Which option best summarizes the main goal of the lesson "{title}"?',
+      fallbackGoalOptions: [
+        '{description}',
+        'Memorize syntax without practicing.',
+        'Avoid reviewing errors to move faster.',
+        'Skip fundamentals and start with advanced topics.',
+      ],
+      fallbackGoalHint: 'Look for the option that describes practical, progressive learning.',
+      fallbackTrueFalseQuestion:
+        'True or false: practicing short examples and validating results improves understanding.',
+      fallbackTrueFalseOptions: ['True', 'False'],
+      fallbackTrueFalseHint: 'Deliberate practice helps solidify knowledge.',
+      fallbackStrategyQuestion: 'To progress in "{title}", which strategy is the most recommended?',
+      fallbackStrategyOptions: [
+        'Practice, review errors, and try again.',
+        'Solve everything without reading theory or hints.',
+        'Copy answers without understanding why.',
+        'Ignore feedback when an answer fails.',
+      ],
+      fallbackStrategyHint: 'Effective learning combines theory, practice, and feedback.',
+      fallbackStrategyExpected: 'Practice, review errors, and try again.',
+      codePromptDefault: 'Complete the missing identifier to finish the "{title}" example.',
+      conceptGoalQuestion: 'Which option best describes the main goal of "{title}"?',
+      conceptGoalOptions: [
+        '{description}',
+        'Memorize syntax without practicing.',
+        'Avoid debugging errors to move faster.',
+        'Ignore the basics and start with advanced topics.',
+      ],
+      conceptGoalHint: 'Think about the main idea explained in the theory.',
+      trueFalseQuestion:
+        'True or false: practicing short examples and validating results helps consolidate what you learned.',
+      trueFalseOptions: ['True', 'False'],
+      trueFalseHint: 'Deliberate practice strengthens understanding.',
+    }
+  }
+
+  return {
+    fallbackGoalQuestion: '¿Que objetivo principal resume mejor la leccion "{title}"?',
+    fallbackGoalOptions: [
+      '{description}',
+      'Memorizar sintaxis sin practicar.',
+      'Evitar revisar errores para avanzar mas rapido.',
+      'Saltar fundamentos y empezar por temas avanzados.',
+    ],
+    fallbackGoalHint: 'Busca la opcion que describe aprendizaje practico y progresivo.',
+    fallbackTrueFalseQuestion:
+      'Verdadero o falso: practicar ejemplos cortos y validar resultados mejora la comprension.',
+    fallbackTrueFalseOptions: ['Verdadero', 'Falso'],
+    fallbackTrueFalseHint: 'La practica deliberada ayuda a consolidar conocimiento.',
+    fallbackStrategyQuestion: 'Para avanzar en "{title}", ¿cual estrategia es la mas recomendable?',
+    fallbackStrategyOptions: [
+      'Practicar, revisar errores y volver a intentar.',
+      'Resolver todo sin leer teoria ni pistas.',
+      'Copiar respuestas sin entender el por que.',
+      'Ignorar retroalimentacion cuando una respuesta falla.',
+    ],
+    fallbackStrategyHint: 'El aprendizaje efectivo combina teoria, practica y retroalimentacion.',
+    fallbackStrategyExpected: 'Practicar, revisar errores y volver a intentar.',
+    codePromptDefault: 'Completa el identificador faltante para finalizar el ejemplo de "{title}".',
+    conceptGoalQuestion: '¿Cuál de estas opciones describe mejor el objetivo principal de "{title}"?',
+    conceptGoalOptions: [
+      '{description}',
+      'Memorizar sintaxis sin practicar.',
+      'Evitar depurar errores para avanzar más rápido.',
+      'Ignorar las bases y comenzar por temas avanzados.',
+    ],
+    conceptGoalHint: 'Piensa en la explicación principal de la teoría.',
+    trueFalseQuestion:
+      'Verdadero o falso: practicar ejemplos cortos y validar resultados ayuda a consolidar lo aprendido.',
+    trueFalseOptions: ['Verdadero', 'Falso'],
+    trueFalseHint: 'La práctica deliberada fortalece la comprensión.',
+  }
+}
+
+function buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp, locale = 'es' }) {
+  const copy = getExerciseBankCopy(locale)
   const baseExerciseXp = Math.floor(totalXp / 3)
   const finalExerciseXp = totalXp - baseExerciseXp * 2
 
@@ -215,14 +294,9 @@ function buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp }) 
     {
       id: 'concept-core',
       tipo: 'opcion_multiple',
-      enunciado: `¿Que objetivo principal resume mejor la leccion "${lessonTitle}"?`,
-      opciones: [
-        lessonDescription,
-        'Memorizar sintaxis sin practicar.',
-        'Evitar revisar errores para avanzar mas rapido.',
-        'Saltar fundamentos y empezar por temas avanzados.',
-      ],
-      pista: 'Busca la opcion que describe aprendizaje practico y progresivo.',
+      enunciado: copy.fallbackGoalQuestion.replace('{title}', lessonTitle),
+      opciones: copy.fallbackGoalOptions.map((option) => option.replace('{description}', lessonDescription)),
+      pista: copy.fallbackGoalHint,
       numero: 1,
       xp_recompensa: baseExerciseXp,
       validator: {
@@ -233,33 +307,27 @@ function buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp }) 
     {
       id: 'practice-habit',
       tipo: 'verdadero_falso',
-      enunciado:
-        'Verdadero o falso: practicar ejemplos cortos y validar resultados mejora la comprension.',
-      opciones: ['Verdadero', 'Falso'],
-      pista: 'La practica deliberada ayuda a consolidar conocimiento.',
+      enunciado: copy.fallbackTrueFalseQuestion,
+      opciones: copy.fallbackTrueFalseOptions,
+      pista: copy.fallbackTrueFalseHint,
       numero: 2,
       xp_recompensa: baseExerciseXp,
       validator: {
         type: 'option_text',
-        expected: 'Verdadero',
+        expected: copy.fallbackTrueFalseOptions[0],
       },
     },
     {
       id: 'study-strategy',
       tipo: 'opcion_multiple',
-      enunciado: `Para avanzar en "${lessonTitle}", ¿cual estrategia es la mas recomendable?`,
-      opciones: [
-        'Practicar, revisar errores y volver a intentar.',
-        'Resolver todo sin leer teoria ni pistas.',
-        'Copiar respuestas sin entender el por que.',
-        'Ignorar retroalimentacion cuando una respuesta falla.',
-      ],
-      pista: 'El aprendizaje efectivo combina teoria, practica y retroalimentacion.',
+      enunciado: copy.fallbackStrategyQuestion.replace('{title}', lessonTitle),
+      opciones: copy.fallbackStrategyOptions,
+      pista: copy.fallbackStrategyHint,
       numero: 3,
       xp_recompensa: finalExerciseXp,
       validator: {
         type: 'option_text',
-        expected: 'Practicar, revisar errores y volver a intentar.',
+        expected: copy.fallbackStrategyExpected,
       },
     },
   ]
@@ -273,7 +341,8 @@ function buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp }) 
  * @param {object} lesson     - fila de la BD con los datos de la lección
  * @param {object} dbSolution - fila de lesson_solutions (opcional)
  */
-function buildLessonExerciseBank(lesson, dbSolution) {
+function buildLessonExerciseBank(lesson, dbSolution, locale = 'es') {
+  const copy = getExerciseBankCopy(locale)
   const lessonTitle = sanitizeDisplayText(lesson.title || 'la leccion') || 'la leccion'
   const rawDescription = sanitizeDisplayText(lesson.description || '')
   const inferredDescription =
@@ -291,11 +360,11 @@ function buildLessonExerciseBank(lesson, dbSolution) {
   const baseCode = String(dbSolution?.base_code || '').trim()
 
   if (!solutionCode || !explanation) {
-    return buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp })
+    return buildFallbackExerciseBank({ lessonTitle, lessonDescription, totalXp, locale })
   }
 
   const safePrompt =
-    prompt || `Completa el identificador faltante para finalizar el ejemplo de "${lessonTitle}".`
+    prompt || copy.codePromptDefault.replace('{title}', lessonTitle)
   const safeBaseCode = baseCode || inferBaseCodeByLanguage(lesson.programming_language_id)
 
   return [
@@ -316,14 +385,9 @@ function buildLessonExerciseBank(lesson, dbSolution) {
     {
       id: 'concept-core',
       tipo: 'opcion_multiple',
-      enunciado: `¿Cuál de estas opciones describe mejor el objetivo principal de "${lessonTitle}"?`,
-      opciones: [
-        lessonDescription,
-        'Memorizar sintaxis sin practicar.',
-        'Evitar depurar errores para avanzar más rápido.',
-        'Ignorar las bases y comenzar por temas avanzados.',
-      ],
-      pista: 'Piensa en la explicación principal de la teoría.',
+      enunciado: copy.conceptGoalQuestion.replace('{title}', lessonTitle),
+      opciones: copy.conceptGoalOptions.map((option) => option.replace('{description}', lessonDescription)),
+      pista: copy.conceptGoalHint,
       numero: 2,
       xp_recompensa: baseExerciseXp,
       validator: {
@@ -334,15 +398,14 @@ function buildLessonExerciseBank(lesson, dbSolution) {
     {
       id: 'practice-habit',
       tipo: 'verdadero_falso',
-      enunciado:
-        'Verdadero o falso: practicar ejemplos cortos y validar resultados ayuda a consolidar lo aprendido.',
-      opciones: ['Verdadero', 'Falso'],
-      pista: 'La práctica deliberada fortalece la comprensión.',
+      enunciado: copy.trueFalseQuestion,
+      opciones: copy.trueFalseOptions,
+      pista: copy.trueFalseHint,
       numero: 3,
       xp_recompensa: finalExerciseXp,
       validator: {
         type: 'option_text',
-        expected: 'Verdadero',
+        expected: copy.trueFalseOptions[0],
       },
     },
   ]
@@ -977,7 +1040,7 @@ class LearningService {
     }
 
     const dbSolution = await this.solutionsRepository.findByLesson(lessonId, { locale: normalizedLocale })
-    const exerciseBank = buildLessonExerciseBank(lesson, dbSolution)
+    const exerciseBank = buildLessonExerciseBank(lesson, dbSolution, normalizedLocale)
     const cleanedTheory = stripLeadingHeading(lesson.content || '')
 
     return {
@@ -1016,7 +1079,7 @@ class LearningService {
     }
 
     const dbSolution = await this.solutionsRepository.findByLesson(lessonId, { locale: normalizedLocale })
-    const exerciseBank = buildLessonExerciseBank(lesson, dbSolution)
+    const exerciseBank = buildLessonExerciseBank(lesson, dbSolution, normalizedLocale)
     const selectedExercise = exerciseBank.find((exercise) => exercise.id === exerciseId)
 
     if (!selectedExercise) {


### PR DESCRIPTION
## Descripción:
Se conectó el flujo demo del backend al idioma activo y al lenguaje seleccionado, reutilizando el patrón i18n ya existente del módulo JavaScript. Además, se agregaron migraciones para traducciones en de contenido demo y learning paths base de Python, Java, C++ y C#.

## Fixes: #87 