### PR TITLE
Añadidura de botón regreso al Landing.

### DIFF
--- a/database/19_fix_current_level_recalculation.sql
+++ b/database/19_fix_current_level_recalculation.sql
@@ -1,0 +1,7 @@
+-- Recalcula current_level en user_stats basado en total_xp real
+-- Fix para el bug donde addXpToStats() no actualizaba current_level
+
+UPDATE user_stats
+SET current_level = FLOOR(total_xp / 500) + 1,
+    updated_at    = NOW()
+WHERE current_level != FLOOR(total_xp / 500) + 1;

--- a/services/auth-service/src/controllers/ranking.controller.js
+++ b/services/auth-service/src/controllers/ranking.controller.js
@@ -5,6 +5,9 @@ const getLeaderboard = asyncHandler(async (req, res) => {
   const scope = req.query.scope === undefined
     ? 'global'
     : parseString(req.query.scope, 'scope', { minLength: 1 })
+  const type = req.query.type === undefined
+    ? 'historical'
+    : parseString(req.query.type, 'type', { minLength: 1 })
   const limit = req.query.limit === undefined
     ? undefined
     : parsePositiveInt(req.query.limit, 'limit')
@@ -12,6 +15,7 @@ const getLeaderboard = asyncHandler(async (req, res) => {
   const data = await authService.getLeaderboard({
     actorUserId: req.user.id,
     scope,
+    type,
     limit,
   })
 

--- a/services/auth-service/src/repositories/user.repository.js
+++ b/services/auth-service/src/repositories/user.repository.js
@@ -467,16 +467,104 @@ class UserRepository {
                            COALESCE(us.current_level, 1) DESC,
                            u.id ASC
                 ) AS rank_position
+          FROM users u
+          LEFT JOIN user_stats us ON us.user_id = u.id
+          WHERE u.is_active = 1
+            AND u.username IS NOT NULL
+            AND u.username <> ''
+        ) AS ranked
+        ORDER BY ranked.rank_position ASC
+        LIMIT ?`,
+      [actorUserId, actorUserId, safeLimit]
+    )
+
+    return rows
+  }
+
+  async getWeeklyLeaderboard({ actorUserId = null, limit = 25 }) {
+    const safeLimit = Math.max(1, Math.min(100, Number(limit) || 25))
+    const [rows] = await this.pool.query(
+      `SELECT ranked.rank_position,
+              ranked.id,
+              ranked.name,
+              ranked.username,
+              ranked.avatar_url,
+              ranked.country_code,
+              ranked.weekly_xp,
+              CASE
+                WHEN ? IS NULL THEN 0
+                WHEN EXISTS (
+                  SELECT 1
+                  FROM user_follows uf
+                  WHERE uf.follower_id = ?
+                    AND uf.following_id = ranked.id
+                ) THEN 1
+                ELSE 0
+              END AS is_following
+       FROM (
+         SELECT u.id,
+                u.name,
+                u.username,
+                u.avatar_url,
+                u.country_code,
+                COALESCE(SUM(us2.points_earned), 0) AS weekly_xp,
+                ROW_NUMBER() OVER (
+                  ORDER BY COALESCE(SUM(us2.points_earned), 0) DESC,
+                           u.id ASC
+                ) AS rank_position
          FROM users u
-         LEFT JOIN user_stats us ON us.user_id = u.id
+         LEFT JOIN user_submissions us2
+           ON us2.user_id = u.id
+          AND us2.created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
          WHERE u.is_active = 1
-           AND u.role = 'user'
            AND u.username IS NOT NULL
            AND u.username <> ''
+         GROUP BY u.id, u.name, u.username, u.avatar_url, u.country_code
        ) AS ranked
        ORDER BY ranked.rank_position ASC
        LIMIT ?`,
       [actorUserId, actorUserId, safeLimit]
+    )
+
+    return rows
+  }
+
+  async getWeeklyFollowingLeaderboard({ actorUserId, limit = 25 }) {
+    const safeLimit = Math.max(1, Math.min(100, Number(limit) || 25))
+    const [rows] = await this.pool.query(
+      `SELECT ranked.rank_position,
+              ranked.id,
+              ranked.name,
+              ranked.username,
+              ranked.avatar_url,
+              ranked.country_code,
+              ranked.weekly_xp,
+              1 AS is_following
+       FROM (
+         SELECT u.id,
+                u.name,
+                u.username,
+                u.avatar_url,
+                u.country_code,
+                COALESCE(SUM(us2.points_earned), 0) AS weekly_xp,
+                ROW_NUMBER() OVER (
+                  ORDER BY COALESCE(SUM(us2.points_earned), 0) DESC,
+                           u.id ASC
+                ) AS rank_position
+         FROM user_follows uf
+         JOIN users u ON u.id = uf.following_id
+         LEFT JOIN user_submissions us2
+           ON us2.user_id = u.id
+          AND us2.created_at >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+         WHERE uf.follower_id = ?
+           AND u.is_active = 1
+           AND u.username IS NOT NULL
+           AND u.username <> ''
+         GROUP BY u.id, u.name, u.username, u.avatar_url, u.country_code
+       ) AS ranked
+       ORDER BY ranked.rank_position ASC
+       LIMIT ?`,
+      [actorUserId, safeLimit]
     )
 
     return rows
@@ -512,14 +600,13 @@ class UserRepository {
          FROM user_follows uf
          JOIN users u ON u.id = uf.following_id
          LEFT JOIN user_stats us ON us.user_id = u.id
-         WHERE uf.follower_id = ?
-           AND u.is_active = 1
-           AND u.role = 'user'
-           AND u.username IS NOT NULL
-           AND u.username <> ''
-       ) AS ranked
-       ORDER BY ranked.rank_position ASC
-       LIMIT ?`,
+          WHERE uf.follower_id = ?
+            AND u.is_active = 1
+            AND u.username IS NOT NULL
+            AND u.username <> ''
+        ) AS ranked
+        ORDER BY ranked.rank_position ASC
+        LIMIT ?`,
       [actorUserId, safeLimit]
     )
 
@@ -649,13 +736,12 @@ class UserRepository {
                   ) AS rank_position
            FROM users u
            LEFT JOIN user_stats us ON us.user_id = u.id
-           WHERE u.is_active = 1
-             AND u.role = 'user'
-             AND u.username IS NOT NULL
-             AND u.username <> ''
-         ) AS ranked
-         WHERE ranked.id = ?
-         LIMIT 1`,
+            WHERE u.is_active = 1
+              AND u.username IS NOT NULL
+              AND u.username <> ''
+          ) AS ranked
+          WHERE ranked.id = ?
+          LIMIT 1`,
         [userId]
       ),
       this.pool.query(
@@ -745,10 +831,9 @@ class UserRepository {
               END AS is_following_back
        FROM users u
        LEFT JOIN user_stats us ON us.user_id = u.id
-       WHERE LOWER(u.username) = LOWER(?)
-         AND u.is_active = 1
-         AND u.role = 'user'
-       LIMIT 1`,
+        WHERE LOWER(u.username) = LOWER(?)
+          AND u.is_active = 1
+        LIMIT 1`,
       [actorUserId, actorUserId, actorUserId, actorUserId, normalizedUsername]
     )
 

--- a/services/auth-service/src/services/auth.service.js
+++ b/services/auth-service/src/services/auth.service.js
@@ -74,6 +74,7 @@ function mapLeaderboardEntry(entry) {
     avatar: entry.avatar_url || null,
     countryCode: entry.country_code || null,
     totalXp: Number(entry.total_xp || 0),
+    weeklyXp: Number(entry.weekly_xp || 0),
     currentLevel: Number(entry.current_level || 1),
     lessonsCompleted: Number(entry.lessons_completed || 0),
     isFollowing: Boolean(entry.is_following),
@@ -589,7 +590,7 @@ class AuthService {
     }
   }
 
-  async getLeaderboard({ actorUserId, scope, limit }) {
+  async getLeaderboard({ actorUserId, scope, type, limit }) {
     await this.schemaGuardService.assertReady()
 
     const actor = await this.userRepository.findById(actorUserId)
@@ -602,10 +603,20 @@ class AuthService {
       throw AppError.badRequest('scope invalido. Usa global o following.', 'VALIDATION_ERROR')
     }
 
+    const normalizedType = String(type || 'historical').trim().toLowerCase()
+    if (!['historical', 'weekly'].includes(normalizedType)) {
+      throw AppError.badRequest('type invalido. Usa historical o weekly.', 'VALIDATION_ERROR')
+    }
+
+    const isWeekly = normalizedType === 'weekly'
     const [entries, counts] = await Promise.all([
-      normalizedScope === 'following'
-        ? this.userRepository.getFollowingLeaderboard({ actorUserId, limit })
-        : this.userRepository.getGlobalLeaderboard({ actorUserId, limit }),
+      isWeekly
+        ? normalizedScope === 'following'
+          ? this.userRepository.getWeeklyFollowingLeaderboard({ actorUserId, limit })
+          : this.userRepository.getWeeklyLeaderboard({ actorUserId, limit })
+        : normalizedScope === 'following'
+          ? this.userRepository.getFollowingLeaderboard({ actorUserId, limit })
+          : this.userRepository.getGlobalLeaderboard({ actorUserId, limit }),
       this.userRepository.getFollowCounts(actorUserId),
     ])
 
@@ -615,6 +626,7 @@ class AuthService {
 
     return {
       scope: normalizedScope,
+      type: normalizedType,
       counts,
       entries: entries.map((entry) => {
         const mappedEntry = mapLeaderboardEntry(entry)

--- a/services/learning-service/src/repositories/progress.repository.js
+++ b/services/learning-service/src/repositories/progress.repository.js
@@ -119,13 +119,14 @@ class ProgressRepository {
     if (normalizedXp === 0) return
 
     await this.pool.query(
-      `INSERT INTO user_stats (user_id, total_xp, submissions_total)
-       VALUES (?, ?, 1)
+      `INSERT INTO user_stats (user_id, total_xp, current_level, submissions_total)
+       VALUES (?, ?, FLOOR(? / 500) + 1, 1)
        ON DUPLICATE KEY UPDATE
          total_xp          = total_xp + ?,
+         current_level     = FLOOR((total_xp + ?) / 500) + 1,
          submissions_total = submissions_total + 1,
          updated_at        = NOW()`,
-      [userId, normalizedXp, normalizedXp]
+      [userId, normalizedXp, normalizedXp, normalizedXp, normalizedXp]
     )
   }
 
@@ -236,11 +237,10 @@ class ProgressRepository {
                 ) AS rank_position
          FROM users u
          LEFT JOIN user_stats us ON us.user_id = u.id
-         WHERE u.is_active = 1
-           AND u.role = 'user'
-           AND u.username IS NOT NULL
-           AND u.username <> ''
-       ) AS ranked
+          WHERE u.is_active = 1
+            AND u.username IS NOT NULL
+            AND u.username <> ''
+        ) AS ranked
        WHERE ranked.id = ?
        LIMIT 1`,
       [userId]


### PR DESCRIPTION
## Issues Relacionadas/Resueltas: #92 #93 #94 #95

## Cambios incluidos

### 🐛 Fix: Nivel corrupto por `current_level` no actualizado
**Archivo:** `services/learning-service/src/repositories/progress.repository.js`

**Problema:** El método `addXpToStats()` sumaba XP a `total_xp` pero no recalculaba `current_level`. Un usuario con 1500 XP aparecía en nivel 3 (estancado) cuando debería estar en nivel 4.

**Solución:** La query INSERT/UPDATE ahora también calcula:
```sql
current_level = FLOOR((total_xp + ?) / 500) + 1
```

### 🗄️ Migración DB: Reparar niveles existentes
**Archivo nuevo:** `database/19_fix_current_level_recalculation.sql`

Recorre `user_stats` y corrige `current_level` donde esté desfasado del `total_xp` real. Se ejecuta automáticamente con `db-migrator`.

### 🏆 Ranking: Incluir todos los roles
**Archivo:** `services/auth-service/src/repositories/user.repository.js`

Se eliminó el filtro `AND u.role = 'user'` de 4 consultas:
- `getGlobalLeaderboard()`
- `getFollowingLeaderboard()`
- `getUserProfileStats()` (subquery de rank)
- `getPublicUserProfileByUsername()`

**Archivo:** `services/learning-service/src/repositories/progress.repository.js`

Se eliminó el mismo filtro de `getRankingStats()`.

### 📊 Ranking: Nuevo ranking semanal
**Archivos modificados:**
- `services/auth-service/src/repositories/user.repository.js` — nuevos métodos `getWeeklyLeaderboard()` y `getWeeklyFollowingLeaderboard()`
- `services/auth-service/src/services/auth.service.js` — `getLeaderboard()` acepta `type` (historical|weekly), mapea `weeklyXp`
- `services/auth-service/src/controllers/ranking.controller.js` — acepta query param `?type=historical|weekly`

**Endpoint:** `GET /api/ranking/leaderboard?type=weekly&scope=global&limit=25`

El ranking semanal suma `points_earned` de `user_submissions` de los últimos 7 días.
